### PR TITLE
Add libsecret support for qtkeychain

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules.git

--- a/org.kde.neochat.json
+++ b/org.kde.neochat.json
@@ -19,6 +19,7 @@
         "--talk-name=org.kde.kwalletd5"
     ],
     "modules": [
+        "shared-modules/libsecret/libsecret.json",
         {
             "name": "qtkeychain",
             "buildsystem": "cmake-ninja",
@@ -29,6 +30,7 @@
             "config-opts": [
                 "-DCMAKE_INSTALL_LIBDIR=/app/lib",
                 "-DLIB_INSTALL_DIR=/app/lib",
+                "-DLIBSECRET_SUPPORT=ON",
                 "-DBUILD_TRANSLATIONS=NO"
             ],
             "sources": [


### PR DESCRIPTION
This should allow NeoChat securely store secrets on non-KDE environments, using secret service instead of kdewallet. I'm not sure which one would be the default if both are available, though.