### PR TITLE
Work around problems with libsecret > 0.20 in flatpak

### DIFF
--- a/org.kde.neochat.json
+++ b/org.kde.neochat.json
@@ -26,7 +26,8 @@
                 "-Dmanpage=false",
                 "-Dvapi=false",
                 "-Dgtk_doc=false",
-                "-Dintrospection=false"
+                "-Dintrospection=false",
+                "-Dgcrypt=false"
             ],
             "sources": [
                 {


### PR DESCRIPTION
This was verified to fix login on gnome-based DEs