### PR TITLE
Allow use of neochat on non-Plasma desktops.

### DIFF
--- a/org.kde.neochat.json
+++ b/org.kde.neochat.json
@@ -16,6 +16,7 @@
         "--socket=wayland",
         "--talk-name=org.freedesktop.Notifications",
         "--talk-name=org.kde.StatusNotifierWatcher",
+        "--talk-name=org.freedesktop.secrets",
         "--talk-name=org.kde.kwalletd5"
     ],
     "modules": [


### PR DESCRIPTION
This allows Neochat to talk to GNOME Keyring which is used on other desktops where Kwallet isn't available.