### PR TITLE
Update to qtkeychain 0.14.1

### DIFF
--- a/org.kde.neochat.json
+++ b/org.kde.neochat.json
@@ -74,13 +74,13 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/frankosterfeld/qtkeychain/archive/v0.14.0.tar.gz",
-                    "sha256": "ad78f2d9e0a5ee80f40cbaace4f55d11c2557bc6e930cf4a9479e39a7d78bb60",
+                    "url": "https://github.com/frankosterfeld/qtkeychain/archive/0.14.1.tar.gz",
+                    "sha256": "afb2d120722141aca85f8144c4ef017bd74977ed45b80e5d9e9614015dadd60c",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 4138,
                         "stable-only": true,
-                        "url-template": "https://github.com/frankosterfeld/qtkeychain/archive/v$version.tar.gz"
+                        "url-template": "https://github.com/frankosterfeld/qtkeychain/archive/$version.tar.gz"
                     }
                 }
             ]


### PR DESCRIPTION
This is a manual update since the URL for this latest version does not comply to the existing url-template.  This commit also updates said url-template.