### PR TITLE
Disable crypto on libsecret

### DIFF
--- a/org.kde.neochat.json
+++ b/org.kde.neochat.json
@@ -42,7 +42,8 @@
                 "-Dmanpage=false",
                 "-Dvapi=false",
                 "-Dgtk_doc=false",
-                "-Dintrospection=false"
+                "-Dintrospection=false",
+                "-Dcrypto=disabled"
             ],
             "sources": [
                 {


### PR DESCRIPTION
This fixes problems with libsecret hanging instead of using the dbus protocol to save and retrieve passwords.