### PR TITLE
Add patch to fix stickers not showing up

### DIFF
--- a/handle-stickers-in-contentmodelrole.patch
+++ b/handle-stickers-in-contentmodelrole.patch
@@ -1,0 +1,27 @@
+From 92bcdf2d325d8e570de768b17db9c0cff3d0c9d4 Mon Sep 17 00:00:00 2001
+From: Akseli Lahtinen <akselmo@akselmo.dev>
+Date: Mon, 19 May 2025 20:48:24 +0300
+Subject: [PATCH] Load stickers properly
+
+This fixes stickers not loading, similar to the patch at
+https://invent.kde.org/network/neochat/-/commit/0cc14f710dc3701971249d9b2d7d6f8362a26163
+---
+ src/models/messagemodel.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/models/messagemodel.cpp b/src/models/messagemodel.cpp
+index 48bd140a4..bc3062a79 100644
+--- a/src/models/messagemodel.cpp
++++ b/src/models/messagemodel.cpp
+@@ -121,7 +121,7 @@ QVariant MessageModel::data(const QModelIndex &idx, int role) const
+     }
+ 
+     if (role == ContentModelRole) {
+-        if (event->get().is<EncryptedEvent>()) {
++        if (event->get().is<EncryptedEvent>() || event->get().is<StickerEvent>()) {
+             return QVariant::fromValue<MessageContentModel *>(m_room->contentModelForEvent(event->get().id()));
+         }
+ 
+-- 
+2.49.0
+

--- a/org.kde.neochat.json
+++ b/org.kde.neochat.json
@@ -213,6 +213,10 @@
                         "stable-only": true,
                         "url-template": "https://download.kde.org/stable/release-service/$version/src/neochat-$version.tar.xz"
                     }
+                },
+                {
+                    "type": "patch",
+                    "path": "handle-stickers-in-contentmodelrole.patch"
                 }
             ]
         }


### PR DESCRIPTION
Adds commit
https://invent.kde.org/network/neochat/-/commit/0cc14f710dc3701971249d9b2d7d6f8362a26163 as a patch
to fix the issue with stickers not loading.