### PR TITLE
Add necessary DBus permissions

### DIFF
--- a/org.kde.neochat.json
+++ b/org.kde.neochat.json
@@ -18,7 +18,8 @@
         "--talk-name=org.kde.StatusNotifierWatcher",
         "--talk-name=org.freedesktop.secrets",
         "--talk-name=org.kde.kwalletd5",
-        "--talk-name=org.kde.kwalletd6"
+        "--talk-name=org.kde.kwalletd6",
+        "--talk-name=org.kde.kuiserver"
     ],
     "modules": [
         {


### PR DESCRIPTION
org.kde.kuiserver lets it talk to KDE's job server so it can display notifications for file upload and download progress.

org.kde.StatusNotifierItem-2-2 lets its status notifier item work.