### PR TITLE
Don't nuke the logging categories

### DIFF
--- a/org.kde.neochat.json
+++ b/org.kde.neochat.json
@@ -33,8 +33,7 @@
         "/mkspecs",
         "/share/app-info",
         "/share/kdevappwizard",
-        "/share/man",
-        "/share/qlogging-categories6"
+        "/share/man"
     ],
     "modules": [
         {


### PR DESCRIPTION
These are needed if we want KDebugSettings to read them in the future, and they're super small.